### PR TITLE
Automate Docker installation for one-click deployment

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,8 @@
 ---
+force_ipv4_for_apt: false
+use_official_docker_repo: true
+use_offline_images: false
+
 brand_name: "НПК КРИПТОНИТ"
 timezone: "Europe/Moscow"
 
@@ -18,7 +22,6 @@ internal_ca_url: >-
 private_ca_root_cert_path: >-
   {{ private_ca_project_path }}/config/certs/root_ca.crt
 
-use_offline_images: false
 docker_image_cache:
   - name: "smallstep/step-ca"
     tag: "0.27.3"

--- a/playbooks/base.yml
+++ b/playbooks/base.yml
@@ -4,6 +4,9 @@
   become: true
   gather_facts: false
   roles:
+    - role: docker
+      tags:
+        - docker
     - role: network
       tags:
         - network

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,57 @@
+---
+force_ipv4_for_apt: false  # noqa var-naming
+
+docker_apt_force_ipv4_path: /etc/apt/apt.conf.d/99force-ipv4
+
+use_official_docker_repo: true  # noqa var-naming
+docker_package_state: present
+docker_service_state: started
+docker_service_enabled: true
+
+docker_required_packages:
+  - ca-certificates
+  - curl
+  - gnupg
+  - lsb-release
+
+docker_additional_packages: []
+
+docker_compose_plugin_package: docker-compose-plugin
+docker_python_package: python3-docker
+docker_official_packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - docker-buildx-plugin
+  - "{{ docker_compose_plugin_package }}"
+  - "{{ docker_python_package }}"
+docker_default_packages:
+  - docker.io
+  - "{{ docker_compose_plugin_package }}"
+  - "{{ docker_python_package }}"
+
+docker_keyring_path: /etc/apt/keyrings/docker.asc
+docker_repository_filename: docker
+docker_apt_gpg_key_url: https://download.docker.com/linux/ubuntu/gpg
+docker_apt_arch_map:
+  x86_64: amd64
+  amd64: amd64
+  aarch64: arm64
+  arm64: arm64
+  armv7l: armhf
+  armhf: armhf
+docker_apt_architecture: >-
+  {{
+    docker_apt_arch_map.get(
+      (ansible_facts | default({})).get('architecture', 'amd64'),
+      'amd64'
+    )
+  }}
+docker_distribution: >-
+  {{ (ansible_facts | default({})).get('distribution', 'Ubuntu') }}
+docker_distribution_release: >-
+  {{ (ansible_facts | default({})).get('distribution_release', 'jammy') }}
+docker_repository: >-
+  deb [arch={{ docker_apt_architecture }} signed-by={{ docker_keyring_path }}]
+  https://download.docker.com/linux/{{ docker_distribution | lower }}
+  {{ docker_distribution_release }} stable

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Docker
+  ansible.builtin.service:
+    name: docker
+    state: restarted

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+- name: Configure APT to force IPv4 when requested
+  ansible.builtin.copy:
+    dest: "{{ docker_apt_force_ipv4_path }}"
+    content: "Acquire::ForceIPv4 \"true\";\n"
+    owner: root
+    group: root
+    mode: '0644'
+  when: force_ipv4_for_apt | bool
+
+- name: Remove APT IPv4 override when not required
+  ansible.builtin.file:
+    path: "{{ docker_apt_force_ipv4_path }}"
+    state: absent
+  when: not (force_ipv4_for_apt | bool)
+
+- name: Install prerequisite packages for Docker
+  ansible.builtin.apt:
+    name: "{{ docker_required_packages }}"
+    state: present
+    update_cache: true
+  when: docker_required_packages | length > 0
+
+- name: Ensure Docker keyring directory exists
+  ansible.builtin.file:
+    path: "{{ docker_keyring_path | dirname }}"
+    state: directory
+    mode: '0755'
+  when: use_official_docker_repo | bool
+
+- name: Download Docker repository key
+  ansible.builtin.get_url:
+    url: "{{ docker_apt_gpg_key_url }}"
+    dest: "{{ docker_keyring_path }}"
+    mode: '0644'
+  when: use_official_docker_repo | bool
+
+- name: Configure Docker APT repository
+  ansible.builtin.apt_repository:
+    repo: "{{ docker_repository }}"
+    filename: "{{ docker_repository_filename }}"
+    state: present
+  when: use_official_docker_repo | bool
+
+- name: Remove Docker APT repository when disabled
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/{{ docker_repository_filename }}.list"
+    state: absent
+  when: not (use_official_docker_repo | bool)
+
+- name: Remove Docker repository key when disabled
+  ansible.builtin.file:
+    path: "{{ docker_keyring_path }}"
+    state: absent
+  when: not (use_official_docker_repo | bool)
+
+- name: Determine Docker packages to install
+  ansible.builtin.set_fact:
+    docker_packages_effective: >-
+      {{
+        (
+          (use_official_docker_repo | bool)
+          | ternary(docker_official_packages, docker_default_packages)
+        ) + docker_additional_packages
+        | unique
+      }}
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name: "{{ docker_packages_effective }}"
+    state: "{{ docker_package_state }}"
+    update_cache: true
+  notify: Restart Docker
+
+- name: Ensure Docker service is enabled and running
+  ansible.builtin.service:
+    name: docker
+    state: "{{ docker_service_state }}"
+    enabled: "{{ docker_service_enabled }}"

--- a/site.yml
+++ b/site.yml
@@ -4,6 +4,11 @@
   become: true
   gather_facts: true
   tasks:
+    - name: Install Docker engine and Compose plugin
+      ansible.builtin.import_role:
+        name: docker
+      tags:
+        - docker
     - name: Load offline Docker images
       ansible.builtin.import_role:
         name: offline_images


### PR DESCRIPTION
## Summary
- add a dedicated docker role that installs Docker Engine, Compose v2 and python3-docker with optional IPv4 forcing
- run the docker role before the rest of the stack so services can rely on Docker being present
- expose safe defaults for Docker installation toggles in the global group vars

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68d1825e2df48321a8a29417ee118b88