### PR TITLE
Add offline image defaults and guard

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -5,6 +5,8 @@ use_official_docker_repo: false
 preflight_enable_disk_checks: false
 
 use_offline_images: false
+offline_images_dir: /opt/kryptonit-stack/images
+offline_archives: []
 
 brand_name: "НПК КРИПТОНИТ"
 timezone: "Europe/Moscow"
@@ -17,13 +19,11 @@ office_domain: "office.{{ base_domain }}"
 infra_network_name: "infra_internal"
 
 private_ca_hostname: "private-ca"
-private_ca_project_path: /opt/private-ca
+private_ca_project_path: "/opt/private-ca"
 private_ca_port: 9000
 private_ca_name: "Infra Private CA"
-internal_ca_url: >-
-  https://private-ca:9000/acme/acme/directory
-private_ca_root_cert_path: >-
-  {{ private_ca_project_path }}/config/certs/root_ca.crt
+internal_ca_url: "https://private-ca:9000/acme/acme/directory"
+private_ca_root_cert_path: "{{ private_ca_project_path }}/config/certs/root_ca.crt"
 
 docker_image_cache:
   - name: "smallstep/step-ca"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -22,8 +22,10 @@ private_ca_hostname: "private-ca"
 private_ca_project_path: "/opt/private-ca"
 private_ca_port: 9000
 private_ca_name: "Infra Private CA"
-internal_ca_url: "https://private-ca:9000/acme/acme/directory"
-private_ca_root_cert_path: "{{ private_ca_project_path }}/config/certs/root_ca.crt"
+internal_ca_url: >-
+  https://private-ca:9000/acme/acme/directory
+private_ca_root_cert_path: >-
+  {{ private_ca_project_path }}/config/certs/root_ca.crt
 
 docker_image_cache:
   - name: "smallstep/step-ca"

--- a/roles/offline_images/defaults/main.yml
+++ b/roles/offline_images/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+use_offline_images: false
+offline_images_dir: /opt/kryptonit-stack/images
+offline_archives: []

--- a/roles/offline_images/defaults/main.yml
+++ b/roles/offline_images/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-use_offline_images: false
-offline_images_dir: /opt/kryptonit-stack/images
-offline_archives: []
+offline_images_enabled: false
+offline_images_directory: /opt/kryptonit-stack/images
+offline_images_default_archives: []

--- a/roles/offline_images/defaults/main.yml
+++ b/roles/offline_images/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-offline_images_enabled: false
-offline_images_directory: /opt/kryptonit-stack/images
-offline_images_default_archives: []
+offline_images_use_offline_images: false
+offline_images_offline_images_dir: /opt/kryptonit-stack/images
+offline_images_offline_archives: []

--- a/roles/offline_images/tasks/main.yml
+++ b/roles/offline_images/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Prepare offline Docker images
-  when: use_offline_images | bool
+  when: (use_offline_images | default(false)) | bool
   tags:
     - offline
   block:

--- a/roles/offline_images/tasks/main.yml
+++ b/roles/offline_images/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
 - name: Prepare offline Docker images
-  when: (
-          use_offline_images
-          | default(offline_images_enabled)
-        ) | bool
+  vars:
+    offline_images_effective_enabled: >-
+      {{ use_offline_images
+         | default(offline_images_use_offline_images) }}
+    offline_images_effective_dir: >-
+      {{ offline_images_dir
+         | default(offline_images_offline_images_dir) }}
+    offline_images_effective_archives: >-
+      {{ offline_archives
+         | default(offline_images_offline_archives)
+         | list }}
+  when: (offline_images_effective_enabled | bool)
   tags:
     - offline
   block:
@@ -16,16 +24,14 @@
 
     - name: Prepare offline archive path list
       ansible.builtin.set_fact:
-        offline_images_archives: >-
-          {{ (offline_archives | default(offline_images_default_archives)
-               | list)
+        offline_images_combined_archives: >-
+          {{ offline_images_effective_archives
              + (offline_images_search.files | default([])
                | map(attribute='path') | list) }}
 
     - name: Determine offline images directory on host
       ansible.builtin.set_fact:
-        offline_images_target_dir: >-
-          {{ offline_images_dir | default(offline_images_directory) }}
+        offline_images_target_dir: "{{ offline_images_effective_dir }}"
 
     - name: Ensure offline image directory exists on host
       become: true
@@ -40,8 +46,8 @@
         src: "{{ item }}"
         dest: "{{ offline_images_target_dir }}/{{ item | basename }}"
         mode: '0644'
-      loop: "{{ offline_images_archives }}"
-      when: offline_images_archives | length > 0
+      loop: "{{ offline_images_combined_archives }}"
+      when: offline_images_combined_archives | length > 0
 
     - name: Load offline images if enabled
       become: true

--- a/roles/offline_images/tasks/main.yml
+++ b/roles/offline_images/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - name: Prepare offline Docker images
-  when: (use_offline_images | default(false)) | bool
+  when: (
+          use_offline_images
+          | default(offline_images_enabled)
+        ) | bool
   tags:
     - offline
   block:
@@ -14,13 +17,20 @@
     - name: Prepare offline archive path list
       ansible.builtin.set_fact:
         offline_images_archives: >-
-          {{ offline_images_search.files | default([])
-             | map(attribute='path') | list }}
+          {{ (offline_archives | default(offline_images_default_archives)
+               | list)
+             + (offline_images_search.files | default([])
+               | map(attribute='path') | list) }}
+
+    - name: Determine offline images directory on host
+      ansible.builtin.set_fact:
+        offline_images_target_dir: >-
+          {{ offline_images_dir | default(offline_images_directory) }}
 
     - name: Ensure offline image directory exists on host
       become: true
       ansible.builtin.file:
-        path: /opt/kryptonit/images
+        path: "{{ offline_images_target_dir }}"
         state: directory
         mode: '0755'
 
@@ -28,7 +38,7 @@
       become: true
       ansible.builtin.copy:
         src: "{{ item }}"
-        dest: "/opt/kryptonit/images/{{ item | basename }}"
+        dest: "{{ offline_images_target_dir }}/{{ item | basename }}"
         mode: '0644'
       loop: "{{ offline_images_archives }}"
       when: offline_images_archives | length > 0
@@ -37,7 +47,8 @@
       become: true
       ansible.builtin.shell: |  # noqa command-instead-of-shell
         set -e
-        for f in /opt/kryptonit/images/*.tar; do
+        target_dir="{{ offline_images_target_dir }}"
+        for f in "${target_dir}"/*.tar; do
           [ -f "$f" ] && docker load -i "$f"
         done
       args:


### PR DESCRIPTION
## Summary
- define offline image flags and directories in global variables so they are always available
- add defaults for the offline_images role and make its main block resilient when vars are unset

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1a6d7219c83218adf273abe33f9db